### PR TITLE
fix build error when debug go files on windows

### DIFF
--- a/server.go
+++ b/server.go
@@ -60,9 +60,11 @@ func parseArguments() (descr ServerDescr) {
 		fh, err := ioutil.TempFile(os.TempDir(), template)
 		if err != nil {
 			descr.exe = fmt.Sprintf("%s/gdlv-debug", os.TempDir())
+			return
 		}
-		defer fh.Close()
 		descr.exe = fh.Name()
+		fh.Close()
+		os.Remove(descr.exe)
 	}
 
 	finish := func(atStart bool, args ...string) {


### PR DESCRIPTION
exec gdlv debug main.go will build error on windows:
`go build go-test: build output  already exists and is not an object file.`

I troubleshoot it and issued to golang:
https://github.com/golang/go/issues/30837

:)