### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use Ctrl+plus and Ctrl+minus, or `config zoom 1.5` to change font size. See `hel
 On Linux and Windows gdlv uses [shiny](https://github.com/golang/exp/tree/master/shiny) to draw its window and receive mouse and keyboard input from the Operating System. On macOS [gio](https://gioui.org/) is used instead. This behavior can be changed using build tags:
 
 ```
-go install -tags=nucular_gio github.com/aarzilli/gdlv
+go install -tags=nucular_gio github.com/aarzilli/gdlv@latest
 ```
 
 will force gdlv to use nucular_gio everywhere, conversely `-tags=nucular_shiny` will select the shiny backend on macOS. Additionally, on macOS, `-tags=nucular_shiny,metal` can be used to make shiny draw using the metal API.


### PR DESCRIPTION
Add required version on install command for go 1.16 or later.