### PR TITLE
Add support for printing integers as binary

### DIFF
--- a/detailviewers.go
+++ b/detailviewers.go
@@ -216,6 +216,9 @@ func formatArray(array []int64, hexaddr bool, mode numberMode, canonical bool, s
 	case octMode:
 		fmtstr = fmt.Sprintf("%%0%do ", size*3)
 		emptyfield = fmt.Sprintf("%*s", size*3+1, "")
+	case binMode:
+		fmtstr = fmt.Sprintf("%%0%db ", size*8)
+		emptyfield = fmt.Sprintf("%*s", size*8+1, "")
 	}
 
 	var addrfmtstr string
@@ -353,7 +356,7 @@ func (dv *detailViewer) stringUpdate(w *nucular.Window) {
 		// nothing to choose
 		w.Spacing(1)
 	case viewByteArray, viewRuneArray:
-		numberMode := numberMode(w.ComboSimple([]string{"Decimal", "Hexadecimal", "Octal"}, int(dv.numberMode), 20))
+		numberMode := numberMode(w.ComboSimple([]string{"Decimal", "Hexadecimal", "Octal", "Binary"}, int(dv.numberMode), 20))
 		if numberMode != dv.numberMode {
 			dv.numberMode = numberMode
 			dv.setupView()
@@ -422,6 +425,9 @@ func (dv *detailViewer) intArrayUpdate(w *nucular.Window) {
 	}
 	if w.OptionText("Octal", mode == octMode) {
 		mode = octMode
+	}
+	if w.OptionText("Binary", mode == binMode) {
+		mode = binMode
 	}
 	if mode != dv.numberMode {
 		dv.numberMode = mode

--- a/infovars.go
+++ b/infovars.go
@@ -31,6 +31,7 @@ const (
 	decMode numberMode = iota
 	hexMode
 	octMode
+	binMode
 )
 
 var changedVariableOpacity uint8
@@ -615,6 +616,9 @@ func showExprMenu(parentw *nucular.Window, exprMenuIdx int, v *Variable, clipb [
 		}
 		if w.OptionText("Octal", v.sfmt.IntFormat == "%#o") {
 			v.sfmt.IntFormat = "%#o"
+		}
+		if w.OptionText("Binary", v.sfmt.IntFormat == "%#b") {
+			v.sfmt.IntFormat = "%#b"
 		}
 		if w.OptionText("Decimal", v.sfmt.IntFormat == "" || v.sfmt.IntFormat == "%d") {
 			v.sfmt.IntFormat = ""

--- a/scopeexpr.go
+++ b/scopeexpr.go
@@ -218,7 +218,7 @@ func parseScopedExprLoad(in string, r *ScopedExpr) string {
 			case 'v':
 				r.MaxVariableRecurse = parseNum()
 				return in[i+1:]
-			case 'x', 'X', 'o', 'O', 'd':
+			case 'x', 'X', 'o', 'O', 'b', 'd':
 				r.Fmt.IntFormat = in[:i+1]
 				return in[i+1:]
 			case 'e', 'f', 'g', 'E', 'F', 'G':


### PR DESCRIPTION
Thanks a lot for gdlv, it's very nice to have a simple and lightweight graphical debugger for Go.

I am currently working on something where I am helped by being able to view integers as binary, and it seemed a natural addition to the already present formats. While I am not familiar with the code base, I tried to find the relevant places to add the new format. It appears to work both in the watch window and the details view. Does it look alright to you?